### PR TITLE
Add documentation for getting a player's trophies

### DIFF
--- a/docs/NadeoLiveServices/Tracks/players-trophies.md
+++ b/docs/NadeoLiveServices/Tracks/players-trophies.md
@@ -1,0 +1,227 @@
+---
+audience: NadeoLiveServices
+description: Gets a player's trophy count along with rankings in World, Continent, Country and Region.
+route: api/token/leaderboard/trophy/player/
+method: POST
+body: NEED HELP, EXAMPLE.
+---
+
+Check if the given player by their UID is on NadeoServices and give their total trophy count alongside their rankings in the World, Continent, Country and Region.
+
+This endpoint also allows for multiple player UIDs in the body.
+
+Example response for the player [Scrapie98](https://trackmania.io/#/player/scrapie)
+
+```json
+{
+    "rankings": [
+        {
+            "countPoint": 194080897,
+            "zones": [
+                {
+                    "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "World",
+                    "ranking": {
+                        "position": 8,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e2106-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Europe",
+                    "ranking": {
+                        "position": 8,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e5bc8-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Belgium",
+                    "ranking": {
+                        "position": 1,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e5e63-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Li\u00e8ge",
+                    "ranking": {
+                        "position": 1,
+                        "length": 0
+                    }
+                }
+            ],
+            "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
+            "echelon": 9
+        }
+    ],
+    "length": 0
+}
+```
+
+Body of above request
+
+```json
+{
+    "listPlayer": [
+        {
+            "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
+        }
+    ]
+}
+```
+
+
+Example response for 3 players, [Scrapie98](https://trackmania.io/#/player/scrapie), [GranaDy.](https://trackmania.io/#/player/granady) and [NottCurious](https://trackmania.io/#/player/nottcurious) passed at once.
+
+```json
+{
+    "rankings": [
+        {
+            "countPoint": 194080897,
+            "zones": [
+                {
+                    "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "World",
+                    "ranking": {
+                        "position": 8,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e2106-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Europe",
+                    "ranking": {
+                        "position": 8,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e5bc8-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Belgium",
+                    "ranking": {
+                        "position": 1,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e5e63-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Li\u00e8ge",
+                    "ranking": {
+                        "position": 1,
+                        "length": 0
+                    }
+                }
+            ],
+            "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
+            "echelon": 9
+        },
+        {
+            "countPoint": 169261629,
+            "zones": [
+                {
+                    "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "World",
+                    "ranking": {
+                        "position": 13,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e2106-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Europe",
+                    "ranking": {
+                        "position": 13,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301ff622-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Germany",
+                    "ranking": {
+                        "position": 5,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "30202744-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Sachsen",
+                    "ranking": {
+                        "position": 1,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "30202b1c-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Dresden",
+                    "ranking": {
+                        "position": 1,
+                        "length": 0
+                    }
+                }
+            ],
+            "accountId": "05477e79-25fd-48c2-84c7-e1621aa46517",
+            "echelon": 8
+        },
+        {
+            "countPoint": 5237868,
+            "zones": [
+                {
+                    "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "World",
+                    "ranking": {
+                        "position": 3124,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "301e2069-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "Asia",
+                    "ranking": {
+                        "position": 47,
+                        "length": 0
+                    }
+                },
+                {
+                    "zoneId": "30205919-7e13-11e8-8060-e284abfd2bc4",
+                    "zoneName": "India",
+                    "ranking": {
+                        "position": 8,
+                        "length": 0
+                    }
+                }
+            ],
+            "accountId": "b73fe3d7-a92a-4a6d-ab9d-49005caec499",
+            "echelon": 6
+        }
+    ],
+    "length": 0
+}
+```
+
+Body of above request
+
+```json
+{
+    "listPlayer": [
+        {
+            "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
+        },
+        {
+            "accountId": "05477e79-25fd-48c2-84c7-e1621aa46517",
+        },
+        {
+            "accountId": "b73fe3d7-a92a-4a6d-ab9d-49005caec499",
+        }
+    ]
+}
+```
+
+Example response if an invalid/non-existent player id is given
+
+```json
+{
+    "rankings": [],
+    "length": 0
+}
+```

--- a/docs/NadeoLiveServices/Tracks/players-trophies.md
+++ b/docs/NadeoLiveServices/Tracks/players-trophies.md
@@ -1,7 +1,7 @@
 ---
 audience: NadeoLiveServices
 description: Gets a player's trophy count along with rankings in World, Continent, Country and Region.
-route: api/token/leaderboard/trophy/player/
+route: /api/token/leaderboard/trophy/player/
 method: POST
 body: NEED HELP, EXAMPLE.
 ---

--- a/docs/NadeoLiveServices/Tracks/players-trophies.md
+++ b/docs/NadeoLiveServices/Tracks/players-trophies.md
@@ -3,14 +3,27 @@ audience: NadeoLiveServices
 description: Gets a player's trophy count along with rankings in World, Continent, Country and Region.
 route: /api/token/leaderboard/trophy/player/
 method: POST
-body: NEED HELP, EXAMPLE.
 ---
 
 Check if the given player by their UID is on NadeoServices and give their total trophy count alongside their rankings in the World, Continent, Country and Region.
 
 This endpoint also allows for multiple player UIDs in the body.
 
-Example response for the player [Scrapie98](https://trackmania.io/#/player/scrapie)
+Example for the player [Scrapie98](https://trackmania.io/#/player/scrapie)
+
+Body:
+
+```json
+{
+    "listPlayer": [
+        {
+            "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
+        }
+    ]
+}
+```
+
+Response:
 
 ```json
 {
@@ -59,20 +72,29 @@ Example response for the player [Scrapie98](https://trackmania.io/#/player/scrap
 }
 ```
 
-Body of above request
+
+Example for 3 players, [Scrapie98](https://trackmania.io/#/player/scrapie), [GranaDy.](https://trackmania.io/#/player/granady) and [NottCurious](https://trackmania.io/#/player/nottcurious) passed at once.
+
+
+Body:
 
 ```json
 {
     "listPlayer": [
         {
             "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
+        },
+        {
+            "accountId": "05477e79-25fd-48c2-84c7-e1621aa46517",
+        },
+        {
+            "accountId": "b73fe3d7-a92a-4a6d-ab9d-49005caec499",
         }
     ]
 }
 ```
 
-
-Example response for 3 players, [Scrapie98](https://trackmania.io/#/player/scrapie), [GranaDy.](https://trackmania.io/#/player/granady) and [NottCurious](https://trackmania.io/#/player/nottcurious) passed at once.
+Response:
 
 ```json
 {
@@ -196,24 +218,6 @@ Example response for 3 players, [Scrapie98](https://trackmania.io/#/player/scrap
         }
     ],
     "length": 0
-}
-```
-
-Body of above request
-
-```json
-{
-    "listPlayer": [
-        {
-            "accountId": "da4642f9-6acf-43fe-88b6-b120ff1308ba",
-        },
-        {
-            "accountId": "05477e79-25fd-48c2-84c7-e1621aa46517",
-        },
-        {
-            "accountId": "b73fe3d7-a92a-4a6d-ab9d-49005caec499",
-        }
-    ]
 }
 ```
 


### PR DESCRIPTION
Adds documentation for getting a player's trophies data. Need some help before changing this from a draft.

When sending a `POST` to `/api/token/leaderboard/trophy/player/` you are required to send a JSON body with a list of player ids in the following format.

```json
{
    "listPlayer": [
        {
            "accountId": "id one",
        },
        {
            "accountId": "id two",
        },
        {
            "accountId": "id three",
        }
    ]
}
```

I do not know how to add this to `parameters` at the top of the file.