### PR TITLE
Leaderboards: add 'surround' route, rename seasonUid -> groupUid

### DIFF
--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
@@ -1,7 +1,7 @@
 ---
 audience: NadeoLiveServices
 url: https://live-services.trackmania.nadeo.live
-route: /api/token/leaderboard/group/{groupUid}/map/{mapUid}/top
+route: /api/token/leaderboard/group/{groupUid}/map/{mapUid}/surround/{nbBefore}/{nbAfter}
 description: Get map records for a group/season
 method: GET
 parameters:
@@ -15,67 +15,197 @@ parameters:
             type: string
             description: The UID of the map
             required: true
+        -   name: nbBefore
+            type: integer
+            description: >
+                The number of records to include immediately before the player's.
+                Note: values greater than 1 don't give any additional records.
+            required: true
+            minimum: 0
+            maximum: 50
+        -   name: nbAfter
+            type: integer
+            description: >
+                The number of records to include immediately after the player's.
+                Note: values greater than 1 don't give any additional records.
+            required: true
+            minimum: 0
+            maximum: 50
     query:
         -   name: onlyWorld
             type: boolean
             description: Whether to return only results for `zoneName == 'World'`
             required: false
             default: false
-        -   name: offset
-            type: integer
-            description: (Requires `onlyWorld=true`) The offset to start from
-            required: false
-            default: 0
-            minimum: 0
-        -   name: length
-            type: integer
-            description: (Requires `onlyWorld=true`) The number of records to return
-            required: false
-            default: 5
-            minimum: 0
-            maximum: 100
         -   name: score
             type: integer
             description: >
-                The player's personal best time in miliseconds. Possibly only used with `seasonUid=Personal_Best`. Unknown purpose.
+                The player's personal best time in miliseconds. Possibly only used with `groupUid=Personal_Best`. Unknown purpose.
 ---
 
-Get the top records for a given map in a given season.
+Get the player's record and the adjacent records for a given map in a given season over all zones.
 
-Note that if `onlyWorld=false` then `offset` and `length` have no effect.
-
-`seasonUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
-
-Note: There is a special seasonUid `Personal_Best` that includes all records set ever.
+Note: There is a special groupUid `Personal_Best` that includes all records set ever.
 
 -----
 
-Example response (`/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc4c2f/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?onlyWorld=true&length=3&offset=92`):
+Example response (`https://live-services.trackmania.nadeo.live/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc4c2f/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/surround/0/1?onlyWorld=true`):
 
 ```json
-
+{
+  "groupUid": "ed0f8dd1-247d-4563-95e2-f8e824dc4c2f",
+  "mapUid": "tZROO7ZGFV5oSel3hyKrvZ60Xth",
+  "tops": [
+    {
+      "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+      "zoneName": "World",
+      "top": [
+        {
+          "accountId": "0a2d1bc0-4aaa-4374-b2db-3d561bdab1c9",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 4264,
+          "score": 57051
+        },
+        {
+          "accountId": "45191988-cf45-456a-a0b9-5a34edb3d219",
+          "zoneId": "301fb654-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Seine-Maritime",
+          "position": 4265,
+          "score": 57065
+        }
+      ]
+    }
+  ]
+}
 ```
 
 -----
 
-Example response (`/api/token/leaderboard/group/Personal_Best/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?onlyWorld=true&length=2`):
+Example response (`https://live-services.trackmania.nadeo.live/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc4c2f/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/surround/50/50`):
 
 ```json
-
-```
-
------
-
-Example response (`/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc4c2f/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?length=1&offset=92`):
-
-```json
+{
+  "groupUid": "ed0f8dd1-247d-4563-95e2-f8e824dc4c2f",
+  "mapUid": "tZROO7ZGFV5oSel3hyKrvZ60Xth",
+  "tops": [
+    {
+      "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+      "zoneName": "World",
+      "top": [
+        {
+          "accountId": "d9285580-3905-449d-af7a-88d6489781f8",
+          "zoneId": "301f3fa4-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Costa Rica",
+          "position": 4263,
+          "score": 57046
+        },
+        {
+          "accountId": "0a2d1bc0-4aaa-4374-b2db-3d561bdab1c9",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 4264,
+          "score": 57051
+        },
+        {
+          "accountId": "45191988-cf45-456a-a0b9-5a34edb3d219",
+          "zoneId": "301fb654-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Seine-Maritime",
+          "position": 4265,
+          "score": 57065
+        }
+      ]
+    },
+    {
+      "zoneId": "301e237a-7e13-11e8-8060-e284abfd2bc4",
+      "zoneName": "Oceania",
+      "top": [
+        {
+          "accountId": "67b85852-0495-43ac-9341-7d16b7dc7f2d",
+          "zoneId": "301e3683-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "South Australia",
+          "position": 46,
+          "score": 56448
+        },
+        {
+          "accountId": "0a2d1bc0-4aaa-4374-b2db-3d561bdab1c9",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 47,
+          "score": 57051
+        },
+        {
+          "accountId": "0286971a-b03d-4060-8a70-85dd064d7f23",
+          "zoneId": "301e3b69-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Victoria",
+          "position": 48,
+          "score": 57160
+        }
+      ]
+    },
+    {
+      "zoneId": "301e2dc2-7e13-11e8-8060-e284abfd2bc4",
+      "zoneName": "Australia",
+      "top": [
+        {
+          "accountId": "67b85852-0495-43ac-9341-7d16b7dc7f2d",
+          "zoneId": "301e3683-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "South Australia",
+          "position": 35,
+          "score": 56448
+        },
+        {
+          "accountId": "0a2d1bc0-4aaa-4374-b2db-3d561bdab1c9",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 36,
+          "score": 57051
+        },
+        {
+          "accountId": "0286971a-b03d-4060-8a70-85dd064d7f23",
+          "zoneId": "301e3b69-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Victoria",
+          "position": 37,
+          "score": 57160
+        }
+      ]
+    },
+    {
+      "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+      "zoneName": "New South Wales",
+      "top": [
+        {
+          "accountId": "9ec43b76-73f7-45d3-a935-0a73b3f06b86",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 6,
+          "score": 50452
+        },
+        {
+          "accountId": "0a2d1bc0-4aaa-4374-b2db-3d561bdab1c9",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 7,
+          "score": 57051
+        },
+        {
+          "accountId": "902dc2a2-6837-4e86-996b-b3c492a53017",
+          "zoneId": "301e309b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "New South Wales",
+          "position": 8,
+          "score": 62463
+        }
+      ]
+    }
+  ]
+}
 ```
 
 -----
 
 Example errors:
 
-when `length < 0` and/or `offset < 0`:
+when `nbAfter < 0` and `nbBefore > 50`:
 ```json
-["length:error-greaterOrEqualThan","offset:error-greaterOrEqualThan"]
+["nbAfter:error-greaterOrEqualThan","nbBefore:error-range"]
 ```

--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
@@ -1,0 +1,80 @@
+---
+audience: NadeoLiveServices
+description: Get map records for a season
+route: /api/token/leaderboard/group/{seasonUid}/map/{mapUid}/top
+method: GET
+parameters:
+    path:
+        -   name: seasonUid
+            type: string
+            description: >
+                The UID of the "season". Example: the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md).
+            required: true
+        -   name: mapUid
+            type: string
+            description: The UID of the map
+            required: true
+    query:
+        -   name: onlyWorld
+            type: boolean
+            description: Whether to return only results for `zoneName == 'World'`
+            required: false
+            default: false
+        -   name: offset
+            type: integer
+            description: (Requires `onlyWorld=true`) The offset to start from
+            required: false
+            default: 0
+            minimum: 0
+        -   name: length
+            type: integer
+            description: (Requires `onlyWorld=true`) The number of records to return
+            required: false
+            default: 5
+            minimum: 0
+            maximum: 100
+        -   name: score
+            type: integer
+            description: >
+                The player's personal best time in miliseconds. Possibly only used with `seasonUid=Personal_Best`. Unknown purpose.
+---
+
+Get the top records for a given map in a given season.
+
+Note that if onlyWorld=false then `offset` and `length` have no effect.
+
+`seasonUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
+
+Note: There is a special seasonUid `Personal_Best` that includes all records set ever.
+
+-----
+
+Example response (`/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc4c2f/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?onlyWorld=true&length=3&offset=92`):
+
+```json
+
+```
+
+-----
+
+Example response (`/api/token/leaderboard/group/Personal_Best/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?onlyWorld=true&length=2`):
+
+```json
+
+```
+
+-----
+
+Example response (`/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc4c2f/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?length=1&offset=92`):
+
+```json
+```
+
+-----
+
+Example errors:
+
+when `length < 0` and/or `offset < 0`:
+```json
+["length:error-greaterOrEqualThan","offset:error-greaterOrEqualThan"]
+```

--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
@@ -1,14 +1,15 @@
 ---
 audience: NadeoLiveServices
-description: Get map records for a season
-route: /api/token/leaderboard/group/{seasonUid}/map/{mapUid}/top
+url: https://live-services.trackmania.nadeo.live
+route: /api/token/leaderboard/group/{groupUid}/map/{mapUid}/top
+description: Get map records for a group/season
 method: GET
 parameters:
     path:
-        -   name: seasonUid
+        -   name: groupUid
             type: string
             description: >
-                The UID of the "season". Example: the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md).
+                The UID of the group (aka. `seasonUid`). Example: the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md).
             required: true
         -   name: mapUid
             type: string
@@ -41,7 +42,7 @@ parameters:
 
 Get the top records for a given map in a given season.
 
-Note that if onlyWorld=false then `offset` and `length` have no effect.
+Note that if `onlyWorld=false` then `offset` and `length` have no effect.
 
 `seasonUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
 

--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md
@@ -41,6 +41,7 @@ parameters:
             type: integer
             description: >
                 The player's personal best time in miliseconds. Possibly only used with `groupUid=Personal_Best`. Unknown purpose.
+            required: false
 ---
 
 Get the player's record and the adjacent records for a given map in a given season over all zones.

--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-top.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-top.md
@@ -34,6 +34,10 @@ parameters:
             default: 5
             minimum: 0
             maximum: 100
+        -   name: score
+            type: integer
+            description: >
+                The player's personal best time in miliseconds. Possibly only used with `seasonUid=Personal_Best`. Unknown purpose.
 ---
 
 Get the top records for a given map in a given season.
@@ -41,6 +45,8 @@ Get the top records for a given map in a given season.
 Note that if onlyWorld=false then `offset` and `length` have no effect.
 
 `seasonUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
+
+Note: There is a special seasonUid `Personal_Best` that includes all records set ever.
 
 -----
 
@@ -75,6 +81,39 @@ Example response (`/api/token/leaderboard/group/ed0f8dd1-247d-4563-95e2-f8e824dc
           "zoneName": "Madeira",
           "position": 95,
           "score": 46102
+        }
+      ]
+    }
+  ]
+}
+```
+
+-----
+
+Example response (`/api/token/leaderboard/group/Personal_Best/map/tZROO7ZGFV5oSel3hyKrvZ60Xth/top?onlyWorld=true&length=2`):
+
+```json
+{
+  "groupUid": "Personal_Best",
+  "mapUid": "tZROO7ZGFV5oSel3hyKrvZ60Xth",
+  "tops": [
+    {
+      "zoneId": "301e1b69-7e13-11e8-8060-e284abfd2bc4",
+      "zoneName": "World",
+      "top": [
+        {
+          "accountId": "d46fb45d-d422-47c9-9785-67270a311e25",
+          "zoneId": "301f555b-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Středočeský kraj",
+          "position": 1,
+          "score": 44821
+        },
+        {
+          "accountId": "d320a237-1b0a-4069-af83-f2c09fbf042e",
+          "zoneId": "301e2e52-7e13-11e8-8060-e284abfd2bc4",
+          "zoneName": "Australian Capital Territory",
+          "position": 2,
+          "score": 44971
         }
       ]
     }

--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-top.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-top.md
@@ -2,14 +2,14 @@
 audience: NadeoLiveServices
 url: https://live-services.trackmania.nadeo.live
 description: Get map records for a season
-route: /api/token/leaderboard/group/{seasonUid}/map/{mapUid}/top
+route: /api/token/leaderboard/group/{groupUid}/map/{mapUid}/top
 method: GET
 parameters:
     path:
-        -   name: seasonUid
+        -   name: groupUid
             type: string
             description: >
-                The UID of the "season". Example: the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md).
+                The UID of the group (aka. season). Example: the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md).
             required: true
         -   name: mapUid
             type: string
@@ -36,17 +36,18 @@ parameters:
             maximum: 100
         -   name: score
             type: integer
+            required: false
             description: >
                 The player's personal best time in miliseconds. Possibly only used with `seasonUid=Personal_Best`. Unknown purpose.
 ---
 
-Get the top records for a given map in a given season.
+Get the top records for a given map in a given group/season.
 
-Note that if onlyWorld=false then `offset` and `length` have no effect.
+Note that if `onlyWorld=false` then `offset` and `length` have no effect.
 
-`seasonUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
+`groupUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
 
-Note: There is a special seasonUid `Personal_Best` that includes all records set ever.
+Note: There is a special groupUid `Personal_Best` that includes all records set ever.
 
 -----
 

--- a/docs/NadeoLiveServices/Leaderboards/Groups/map-records-top.md
+++ b/docs/NadeoLiveServices/Leaderboards/Groups/map-records-top.md
@@ -38,7 +38,7 @@ parameters:
             type: integer
             required: false
             description: >
-                The player's personal best time in miliseconds. Possibly only used with `seasonUid=Personal_Best`. Unknown purpose.
+                The player's personal best time in miliseconds. Possibly only used with `groupUid=Personal_Best`. Unknown purpose.
 ---
 
 Get the top records for a given map in a given group/season.

--- a/docs/NadeoLiveServices/Leaderboards/season-leaderboard-top.md
+++ b/docs/NadeoLiveServices/Leaderboards/season-leaderboard-top.md
@@ -2,11 +2,11 @@
 audience: NadeoLiveServices
 url: https://live-services.trackmania.nadeo.live
 description: Get the leaderboard for a season
-route: /api/token/leaderboard/group/{seasonUid}/top
+route: /api/token/leaderboard/group/{groupUid}/top
 method: GET
 parameters:
     path:
-        -   name: seasonUid
+        -   name: groupUid
             type: string
             description: >
                 The UID of the "season". Example: the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md).
@@ -36,7 +36,7 @@ Get the leaderboard for a given season.
 
 Note that if onlyWorld=false then `offset` and `length` have no effect.
 
-`seasonUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
+`groupUid` Example: see the `.seasonUid` field in [Track of the Day entries](/docs/NadeoLiveServices/Campaigns/track-of-the-day.md)
 
 -----
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "build": "node script/build.js"
+    "build": "node script/build.js",
+    "dev": "node script/build.js --dry-run"
   },
   "repository": {
     "type": "git",

--- a/script/build.js
+++ b/script/build.js
@@ -63,7 +63,5 @@ let allFilesCategorized = {},
     const dryRun = ['-n', '--dry-run'].map(v => process.argv.includes(v)).includes(true);
     if (!dryRun) {
         fs.writeFileSync('./api/docs.json', JSON.stringify(root, null, 4));
-    } else {
-        console.info('Dry Run: skipping writing output to ./api/docs.json.');
     }
 })();

--- a/script/build.js
+++ b/script/build.js
@@ -60,5 +60,10 @@ let allFilesCategorized = {},
     root.categories = allFilesCategorized;
 
     console.log(JSON.stringify(root, null, 2));
-    fs.writeFileSync('./api/docs.json', JSON.stringify(root, null, 4));
+    const dryRun = ['-n', '--dry-run'].map(v => process.argv.includes(v)).includes(true);
+    if (!dryRun) {
+        fs.writeFileSync('./api/docs.json', JSON.stringify(root, null, 4));
+    } else {
+        console.info('Dry Run: skipping writing output to ./api/docs.json.');
+    }
 })();


### PR DESCRIPTION
This PR primarily adds docs/NadeoLiveServices/Leaderboards/Groups/map-records-surround.md, but there are some other changes worth noting:

* `seasonUid` should probably be `groupUid` -- not only is this the field name in the response, but `seasonUid` is a name I used in my code only b/c of the TOTD field. Probably better to correct this earlier rather than later.
* added note about special `Personal_Best` group to relevant routes.
* I added a very simple 'dry run' mode to build.js so that I could test the build script runs okay without modifying ./api/docs.json
  * i'm not attached to this -- happy to remove, but IMO it's useful